### PR TITLE
ci: update actions to their latest versions, and use node 18

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: 18
         cache: 'npm'
 
     - name: Cache node_modules

--- a/check-locale/action.yml
+++ b/check-locale/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: 18
         cache: 'npm'
 
     - name: Cache node_modules
@@ -52,6 +52,7 @@ runs:
       if: steps.changed-files.outputs.all_changed_files == 'true'
       uses: thollander/actions-comment-pull-request@v1
       with:
+        comment_includes: 'Language file analysis report'
         message: |
           Language file analysis report:
           |File|Missing Keys|Unused Keys|

--- a/debs-cache/action.yml
+++ b/debs-cache/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Install node
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: 18
         cache: 'npm'
 
     - name: Cache dependencies

--- a/eslint/action.yml
+++ b/eslint/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: 18
         cache: 'npm'
 
     - name: Cache node_modules

--- a/prettier/action.yml
+++ b/prettier/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: 18
         cache: 'npm'
 
     - name: Cache node_modules

--- a/size-report/action.yml
+++ b/size-report/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: 18
         cache: 'npm'
 
     - name: Cache node_modules

--- a/test-cypress/action.yml
+++ b/test-cypress/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: 18
         cache: 'npm'
 
     - name: Cache node_modules
@@ -35,4 +35,4 @@ runs:
     - name: Cypress run
       uses: cypress-io/github-action@v4
       with:
-        start: npm start
+        start: npm run preview


### PR DESCRIPTION
Use node 18, and update everything to the latest available version